### PR TITLE
feat!: Add RDS proxy

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,5 @@
+# Breaking Changes
+
+## 2.0.0
+
+The output `instance_id` now returns the database identifier instead of the database id.

--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ module "db" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_db"></a> [db](#module\_db) | cloudposse/rds/aws | 0.41.0 |
+| <a name="module_db"></a> [db](#module\_db) | cloudposse/rds/aws | 1.0.0 |
+| <a name="module_proxy_label"></a> [proxy\_label](#module\_proxy\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_rds_proxy"></a> [rds\_proxy](#module\_rds\_proxy) | cloudposse/rds-db-proxy/aws | 1.1.0 |
 | <a name="module_sg"></a> [sg](#module\_sg) | cloudposse/security-group/aws | 2.0.0 |
 | <a name="module_ssm_label"></a> [ssm\_label](#module\_ssm\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
@@ -92,65 +95,78 @@ module "db" {
 | Name | Type |
 |------|------|
 | [aws_iam_policy.ssm_get](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_secretsmanager_secret.rds_username_and_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.rds_username_and_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_parameter.db_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [null_resource.password_validation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_iam_policy_document.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in GBs | `number` | `null` | no |
-| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Allow major version upgrade | `bool` | `false` | no |
-| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | The whitelisted CIDRs which to allow `ingress` traffic to the DB instance | `list(string)` | `[]` | no |
-| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window | `bool` | `false` | no |
-| <a name="input_associate_security_group_ids"></a> [associate\_security\_group\_ids](#input\_associate\_security\_group\_ids) | The IDs of the existing security groups to associate with the DB instance | `list(string)` | `[]` | no |
+| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in GBs. | `number` | `null` | no |
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Allow major version upgrade. | `bool` | `false` | no |
+| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | The whitelisted CIDRs which to allow `ingress` traffic to the DB instance. | `list(string)` | `[]` | no |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately, or during the next maintenance window. | `bool` | `false` | no |
+| <a name="input_associate_security_group_ids"></a> [associate\_security\_group\_ids](#input\_associate\_security\_group\_ids) | The IDs of the existing security groups to associate with the DB instance. | `list(string)` | `[]` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4) | `bool` | `true` | no |
-| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Backup retention period in days. Must be > 0 to enable backups | `number` | `0` | no |
-| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | When AWS can perform DB snapshots, can't overlap with maintenance window | `string` | `"22:00-03:00"` | no |
-| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | The identifier of the CA certificate for the DB instance | `string` | `null` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4). | `bool` | `true` | no |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Backup retention period in days. Must be > 0 to enable backups. | `number` | `0` | no |
+| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | When AWS can perform DB snapshots, can't overlap with maintenance window. | `string` | `"22:00-03:00"` | no |
+| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | The identifier of the CA certificate for the DB instance. | `string` | `null` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
-| <a name="input_copy_tags_to_snapshot"></a> [copy\_tags\_to\_snapshot](#input\_copy\_tags\_to\_snapshot) | Copy tags from DB to a snapshot | `bool` | `true` | no |
-| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the database to create when the DB instance is created | `string` | n/a | yes |
-| <a name="input_database_password"></a> [database\_password](#input\_database\_password) | (Required unless a snapshot\_identifier or replicate\_source\_db is provided)<br>BASE64 encoded Password for the master DB user<br>The password for the database master user can include any printable ASCII character except /, ", @, or a space | `string` | `""` | no |
-| <a name="input_database_port"></a> [database\_port](#input\_database\_port) | Database port (\_e.g.\_ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids` | `number` | `5432` | no |
-| <a name="input_database_user"></a> [database\_user](#input\_database\_user) | (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user | `string` | `""` | no |
-| <a name="input_db_options"></a> [db\_options](#input\_db\_options) | A list of DB options to apply with an option group. Depends on DB engine | <pre>list(object({<br>    db_security_group_memberships  = list(string)<br>    option_name                    = string<br>    port                           = number<br>    version                        = string<br>    vpc_security_group_memberships = list(string)<br><br>    option_settings = list(object({<br>      name  = string<br>      value = string<br>    }))<br>  }))</pre> | `[]` | no |
-| <a name="input_db_parameter"></a> [db\_parameter](#input\_db\_parameter) | A list of DB parameters to apply. Note that parameters may differ from a DB family to another | <pre>list(object({<br>    apply_method = string<br>    name         = string<br>    value        = string<br>  }))</pre> | `[]` | no |
-| <a name="input_db_parameter_group"></a> [db\_parameter\_group](#input\_db\_parameter\_group) | The DB parameter group family name. The value depends on DB engine used. See [DBParameterGroupFamily](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBParameterGroup.html#API_CreateDBParameterGroup_RequestParameters) for instructions on how to retrieve applicable value. | `string` | n/a | yes |
-| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Set to true to enable deletion protection on the RDS instance | `bool` | `true` | no |
+| <a name="input_copy_tags_to_snapshot"></a> [copy\_tags\_to\_snapshot](#input\_copy\_tags\_to\_snapshot) | Copy tags from DB to a snapshot. | `bool` | `true` | no |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the database to create when the DB instance is created. | `string` | n/a | yes |
+| <a name="input_database_password"></a> [database\_password](#input\_database\_password) | (Required unless a snapshot\_identifier or replicate\_source\_db is provided)<br>BASE64 encoded Password for the master DB user.<br>The password for the database master user can include any printable ASCII character except /, ", @, or a space. | `string` | `""` | no |
+| <a name="input_database_port"></a> [database\_port](#input\_database\_port) | Database port (\_e.g.\_ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids`. | `number` | `5432` | no |
+| <a name="input_database_user"></a> [database\_user](#input\_database\_user) | (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user. | `string` | `""` | no |
+| <a name="input_db_options"></a> [db\_options](#input\_db\_options) | A list of DB options to apply with an option group. Depends on DB engine. | <pre>list(object({<br>    db_security_group_memberships  = list(string)<br>    option_name                    = string<br>    port                           = number<br>    version                        = string<br>    vpc_security_group_memberships = list(string)<br><br>    option_settings = list(object({<br>      name  = string<br>      value = string<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_db_parameter"></a> [db\_parameter](#input\_db\_parameter) | A list of DB parameters to apply. Note that parameters may differ from a DB family to another. | <pre>list(object({<br>    apply_method = string<br>    name         = string<br>    value        = string<br>  }))</pre> | `[]` | no |
+| <a name="input_db_parameter_group"></a> [db\_parameter\_group](#input\_db\_parameter\_group) | The DB parameter group family name. The value depends on DB engine used.<br>See [DBParameterGroupFamily](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBParameterGroup.html#API_CreateDBParameterGroup_RequestParameters) for instructions on how to retrieve applicable value." | `string` | n/a | yes |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Set to true to enable deletion protection on the RDS instance. | `bool` | `true` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace, postgresql (PostgreSQL), upgrade (PostgreSQL). | `list(string)` | `[]` | no |
-| <a name="input_engine"></a> [engine](#input\_engine) | Database engine type | `string` | `"postgres"` | no |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Database engine version, depends on engine type | `string` | n/a | yes |
+| <a name="input_engine"></a> [engine](#input\_engine) | Database engine type. | `string` | `"postgres"` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Database engine version, depends on engine type. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Class of RDS instance | `string` | n/a | yes |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the existing KMS key to encrypt storage | `string` | `""` | no |
+| <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Class of RDS instance. | `string` | n/a | yes |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the existing KMS key to encrypt storage. | `string` | `""` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC | `string` | `"Mon:03:00-Mon:04:00"` | no |
-| <a name="input_major_engine_version"></a> [major\_engine\_version](#input\_major\_engine\_version) | Database MAJOR engine version, depends on engine type | `string` | `""` | no |
-| <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Set to true if multi AZ deployment must be supported | `bool` | `false` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC. | `string` | `"Mon:03:00-Mon:04:00"` | no |
+| <a name="input_major_engine_version"></a> [major\_engine\_version](#input\_major\_engine\_version) | Database MAJOR engine version, depends on engine type. | `string` | `""` | no |
+| <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Set to true if multi AZ deployment must be supported. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-| <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | Name of the DB option group to associate | `string` | `""` | no |
-| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Name of the DB parameter group to associate | `string` | `""` | no |
-| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Determines if database can be publicly available (NOT recommended) | `bool` | `false` | no |
+| <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | Name of the DB option group to associate. | `string` | `""` | no |
+| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | Name of the DB parameter group to associate. | `string` | `""` | no |
+| <a name="input_proxy_connection_borrow_timeout"></a> [proxy\_connection\_borrow\_timeout](#input\_proxy\_connection\_borrow\_timeout) | The number of seconds for a proxy to wait for a connection to become available in the connection pool. Only applies when the proxy has opened its maximum number of connections and all connections are busy with client sessions. | `number` | `120` | no |
+| <a name="input_proxy_debug_logging"></a> [proxy\_debug\_logging](#input\_proxy\_debug\_logging) | Whether the proxy includes detailed information about SQL statements in its logs. | `bool` | `false` | no |
+| <a name="input_proxy_enabled"></a> [proxy\_enabled](#input\_proxy\_enabled) | Set to `true` to enable RDS proxy. Only available for Postgre and MySQL engines. | `bool` | `false` | no |
+| <a name="input_proxy_existing_iam_role_arn"></a> [proxy\_existing\_iam\_role\_arn](#input\_proxy\_existing\_iam\_role\_arn) | The ARN of an existing IAM role that the proxy can use to access secrets in AWS Secrets Manager. If not provided, the module will create a role to access secrets in Secrets Manager. | `string` | `null` | no |
+| <a name="input_proxy_idle_client_timeout"></a> [proxy\_idle\_client\_timeout](#input\_proxy\_idle\_client\_timeout) | The number of seconds that a connection to the proxy can be inactive before the proxy disconnects it. | `number` | `1800` | no |
+| <a name="input_proxy_init_query"></a> [proxy\_init\_query](#input\_proxy\_init\_query) | One or more SQL statements for the proxy to run when opening each new database connection. | `string` | `null` | no |
+| <a name="input_proxy_max_connections_percent"></a> [proxy\_max\_connections\_percent](#input\_proxy\_max\_connections\_percent) | The maximum size of the connection pool for each target in a target group. | `number` | `100` | no |
+| <a name="input_proxy_max_idle_connections_percent"></a> [proxy\_max\_idle\_connections\_percent](#input\_proxy\_max\_idle\_connections\_percent) | Controls how actively the proxy closes idle database connections in the connection pool. A high value enables the proxy to leave a high percentage of idle connections open. A low value causes the proxy to close idle client connections and return the underlying database connections to the connection pool. | `number` | `50` | no |
+| <a name="input_proxy_require_tls"></a> [proxy\_require\_tls](#input\_proxy\_require\_tls) | A Boolean parameter that specifies whether Transport Layer Security (TLS) encryption is required for connections to the proxy. By enabling this setting, you can enforce encrypted TLS connections to the proxy. | `bool` | `false` | no |
+| <a name="input_proxy_session_pinning_filters"></a> [proxy\_session\_pinning\_filters](#input\_proxy\_session\_pinning\_filters) | Each item in the list represents a class of SQL operations that normally cause all later statements in a session using a proxy to be pinned to the same underlying database connection. | `list(string)` | `null` | no |
+| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Determines if database can be publicly available (NOT recommended). | `bool` | `false` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The IDs of the security groups from which to allow `ingress` traffic to the DB instance | `list(string)` | `[]` | no |
-| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | If true (default), no snapshot will be made before deleting DB | `bool` | `false` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The IDs of the security groups from which to allow `ingress` traffic to the DB instance. | `list(string)` | `[]` | no |
+| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | If true (default), no snapshot will be made before deleting DB. | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | (Optional) Specifies whether the DB instance is encrypted. The default is false if not specified | `bool` | `true` | no |
-| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD) | `string` | `"gp2"` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone` | `list(string)` | `[]` | no |
+| <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | (Optional) Specifies whether the DB instance is encrypted. The default is false if not specified. | `bool` | `true` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). | `string` | `"gp2"` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID the DB instance will be created in | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID the DB instance will be created in. | `string` | n/a | yes |
 ## Outputs
 
 | Name | Description |
@@ -167,6 +183,20 @@ module "db" {
 | <a name="output_option_group_id"></a> [option\_group\_id](#output\_option\_group\_id) | ID of the Option Group |
 | <a name="output_parameter_group_id"></a> [parameter\_group\_id](#output\_parameter\_group\_id) | ID of the Parameter Group |
 | <a name="output_password_ssm_arn"></a> [password\_ssm\_arn](#output\_password\_ssm\_arn) | ARN of the SSM parameter for the database password |
+| <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | Proxy ARN |
+| <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) representing the default target group |
+| <a name="output_proxy_default_target_group_name"></a> [proxy\_default\_target\_group\_name](#output\_proxy\_default\_target\_group\_name) | The name of the default target group |
+| <a name="output_proxy_enabled"></a> [proxy\_enabled](#output\_proxy\_enabled) | Whether or not the database proxy is enabled |
+| <a name="output_proxy_endpoint"></a> [proxy\_endpoint](#output\_proxy\_endpoint) | Proxy endpoint |
+| <a name="output_proxy_iam_role_arn"></a> [proxy\_iam\_role\_arn](#output\_proxy\_iam\_role\_arn) | The ARN of the IAM role that the proxy uses to access secrets in AWS Secrets Manager |
+| <a name="output_proxy_id"></a> [proxy\_id](#output\_proxy\_id) | Proxy ID |
+| <a name="output_proxy_target_endpoint"></a> [proxy\_target\_endpoint](#output\_proxy\_target\_endpoint) | Hostname for the target RDS DB Instance. Only returned for `RDS_INSTANCE` type |
+| <a name="output_proxy_target_id"></a> [proxy\_target\_id](#output\_proxy\_target\_id) | Identifier of `db_proxy_name`, `target_group_name`, `target type` (e.g. `RDS_INSTANCE` or `TRACKED_CLUSTER`), and resource identifier separated by forward slashes (`/`) |
+| <a name="output_proxy_target_port"></a> [proxy\_target\_port](#output\_proxy\_target\_port) | Port for the target RDS DB instance or Aurora DB cluster |
+| <a name="output_proxy_target_rds_resource_id"></a> [proxy\_target\_rds\_resource\_id](#output\_proxy\_target\_rds\_resource\_id) | Identifier representing the DB instance or DB cluster target |
+| <a name="output_proxy_target_target_arn"></a> [proxy\_target\_target\_arn](#output\_proxy\_target\_target\_arn) | Amazon Resource Name (ARN) for the DB instance or DB cluster |
+| <a name="output_proxy_target_tracked_cluster_id"></a> [proxy\_target\_tracked\_cluster\_id](#output\_proxy\_target\_tracked\_cluster\_id) | DB Cluster identifier for the DB instance target. Not returned unless manually importing an `RDS_INSTANCE` target that is part of a DB cluster |
+| <a name="output_proxy_target_type"></a> [proxy\_target\_type](#output\_proxy\_target\_type) | Type of target. e.g. `RDS_INSTANCE` or `TRACKED_CLUSTER` |
 | <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id) | The RDS Resource ID of this instance |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the Security Group |
 | <a name="output_security_group_id_self"></a> [security\_group\_id\_self](#output\_security\_group\_id\_self) | ID of the Security Group with self referencing ingress |

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,28 @@
 locals {
-  enabled = module.this.enabled
+  enabled       = module.this.enabled
+  proxy_enabled = module.this.enabled && var.proxy_enabled
+
+  ssm_get_arn      = join("", aws_ssm_parameter.db_password.*.arn)
+  password_decoded = base64decode(var.database_password)
+
+  username_password = {
+    username = var.database_user
+    password = local.password_decoded
+  }
+
+  auth = [{
+    auth_scheme = "SECRETS"
+    description = "Access the database instance using username and password from AWS Secrets Manager"
+    iam_auth    = "DISABLED"
+    secret_arn  = join("", aws_secretsmanager_secret.rds_username_and_password.*.arn)
+  }]
+
+  proxy_engine_family = var.engine == "mysql" ? "MYSQL" : (var.engine == "postgres" ? "POSTGRESQL" : null)
 }
 
 module "db" {
   source  = "cloudposse/rds/aws"
-  version = "0.41.0"
+  version = "1.0.0"
 
   security_group_ids              = concat([module.sg.id], var.security_group_ids)
   associate_security_group_ids    = var.associate_security_group_ids
@@ -89,11 +107,6 @@ resource "aws_ssm_parameter" "db_password" {
   tags = module.this.tags
 }
 
-locals {
-  ssm_get_arn      = join("", aws_ssm_parameter.db_password.*.arn)
-  password_decoded = base64decode(var.database_password)
-}
-
 data "aws_iam_policy_document" "ssm" {
   statement {
     sid       = "AllowReadSsmParameterDbPassword"
@@ -116,4 +129,61 @@ resource "aws_iam_policy" "ssm_get" {
   policy = data.aws_iam_policy_document.ssm.json
 
   tags = module.this.tags
+}
+
+module "proxy_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled    = local.proxy_enabled
+  attributes = compact(concat(module.this.attributes, ["proxy"]))
+  context    = module.this.context
+}
+
+resource "aws_secretsmanager_secret" "rds_username_and_password" {
+  count = local.proxy_enabled ? 1 : 0
+
+  name                    = module.proxy_label.id
+  description             = "RDS username and password"
+  recovery_window_in_days = 0
+  tags                    = module.proxy_label.tags
+}
+
+resource "aws_secretsmanager_secret_version" "rds_username_and_password" {
+  count = local.proxy_enabled ? 1 : 0
+
+  secret_id     = join("", aws_secretsmanager_secret.rds_username_and_password.*.id)
+  secret_string = jsonencode(local.username_password)
+}
+
+module "rds_proxy" {
+  source  = "cloudposse/rds-db-proxy/aws"
+  version = "1.1.0"
+
+  db_instance_identifier = module.db.instance_id
+  auth                   = local.auth
+  vpc_security_group_ids = concat([module.sg.id], var.security_group_ids)
+  vpc_subnet_ids         = var.subnet_ids
+
+  debug_logging                = var.proxy_debug_logging
+  engine_family                = local.proxy_engine_family
+  idle_client_timeout          = var.proxy_idle_client_timeout
+  require_tls                  = var.proxy_require_tls
+  connection_borrow_timeout    = var.proxy_connection_borrow_timeout
+  init_query                   = var.proxy_init_query
+  max_connections_percent      = var.proxy_max_connections_percent
+  max_idle_connections_percent = var.proxy_max_idle_connections_percent
+  session_pinning_filters      = var.proxy_session_pinning_filters
+  existing_iam_role_arn        = var.proxy_existing_iam_role_arn
+
+  context = module.proxy_label.context
+}
+
+resource "null_resource" "password_validation" {
+  lifecycle {
+    precondition {
+      condition     = !(local.proxy_enabled && var.database_password == "")
+      error_message = "The `database_password` is required when `proxy_enabled` is `true`."
+    }
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -77,3 +77,73 @@ output "enabled" {
   value       = var.enabled
   description = "Whether or not the database is enabled"
 }
+
+output "proxy_enabled" {
+  value       = local.proxy_enabled
+  description = "Whether or not the database proxy is enabled"
+}
+
+output "proxy_id" {
+  value       = module.rds_proxy.proxy_id
+  description = "Proxy ID"
+}
+
+output "proxy_arn" {
+  value       = module.rds_proxy.proxy_arn
+  description = "Proxy ARN"
+}
+
+output "proxy_endpoint" {
+  value       = module.rds_proxy.proxy_endpoint
+  description = "Proxy endpoint"
+}
+
+output "proxy_target_endpoint" {
+  value       = module.rds_proxy.proxy_target_endpoint
+  description = "Hostname for the target RDS DB Instance. Only returned for `RDS_INSTANCE` type"
+}
+
+output "proxy_target_id" {
+  value       = module.rds_proxy.proxy_target_id
+  description = "Identifier of `db_proxy_name`, `target_group_name`, `target type` (e.g. `RDS_INSTANCE` or `TRACKED_CLUSTER`), and resource identifier separated by forward slashes (`/`)"
+}
+
+output "proxy_target_port" {
+  value       = module.rds_proxy.proxy_target_port
+  description = "Port for the target RDS DB instance or Aurora DB cluster"
+}
+
+output "proxy_target_rds_resource_id" {
+  value       = module.rds_proxy.proxy_target_rds_resource_id
+  description = "Identifier representing the DB instance or DB cluster target"
+}
+
+output "proxy_target_target_arn" {
+  value       = module.rds_proxy.proxy_target_target_arn
+  description = "Amazon Resource Name (ARN) for the DB instance or DB cluster"
+}
+
+output "proxy_target_tracked_cluster_id" {
+  value       = module.rds_proxy.proxy_target_tracked_cluster_id
+  description = "DB Cluster identifier for the DB instance target. Not returned unless manually importing an `RDS_INSTANCE` target that is part of a DB cluster"
+}
+
+output "proxy_target_type" {
+  value       = module.rds_proxy.proxy_target_type
+  description = "Type of target. e.g. `RDS_INSTANCE` or `TRACKED_CLUSTER`"
+}
+
+output "proxy_default_target_group_arn" {
+  value       = module.rds_proxy.proxy_default_target_group_arn
+  description = "The Amazon Resource Name (ARN) representing the default target group"
+}
+
+output "proxy_default_target_group_name" {
+  value       = module.rds_proxy.proxy_default_target_group_name
+  description = "The name of the default target group"
+}
+
+output "proxy_iam_role_arn" {
+  value       = module.rds_proxy.proxy_iam_role_arn
+  description = "The ARN of the IAM role that the proxy uses to access secrets in AWS Secrets Manager"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,30 +1,30 @@
 variable "security_group_ids" {
   type        = list(string)
   default     = []
-  description = "The IDs of the security groups from which to allow `ingress` traffic to the DB instance"
+  description = "The IDs of the security groups from which to allow `ingress` traffic to the DB instance."
 }
 
 variable "allowed_cidr_blocks" {
   type        = list(string)
   default     = []
-  description = "The whitelisted CIDRs which to allow `ingress` traffic to the DB instance"
+  description = "The whitelisted CIDRs which to allow `ingress` traffic to the DB instance."
 }
 
 variable "associate_security_group_ids" {
   type        = list(string)
   default     = []
-  description = "The IDs of the existing security groups to associate with the DB instance"
+  description = "The IDs of the existing security groups to associate with the DB instance."
 }
 
 variable "database_name" {
   type        = string
-  description = "The name of the database to create when the DB instance is created"
+  description = "The name of the database to create when the DB instance is created."
 }
 
 variable "database_user" {
   type        = string
   default     = ""
-  description = "(Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user"
+  description = "(Required unless a `snapshot_identifier` or `replicate_source_db` is provided) Username for the master DB user."
 }
 
 variable "database_password" {
@@ -33,149 +33,150 @@ variable "database_password" {
   default     = ""
   description = <<-EOT
     (Required unless a snapshot_identifier or replicate_source_db is provided)
-    BASE64 encoded Password for the master DB user
-    The password for the database master user can include any printable ASCII character except /, ", @, or a space
-    EOT
+    BASE64 encoded Password for the master DB user.
+    The password for the database master user can include any printable ASCII character except /, ", @, or a space.
+  EOT
 }
 
 variable "database_port" {
   type        = number
-  description = "Database port (_e.g._ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids`"
   default     = 5432
+  description = "Database port (_e.g._ `3306` for `MySQL`). Used in the DB Security Group to allow access to the DB instance from the provided `security_group_ids`."
 }
 
 variable "deletion_protection" {
   type        = bool
-  description = "Set to true to enable deletion protection on the RDS instance"
   default     = true
+  description = "Set to true to enable deletion protection on the RDS instance."
 }
 
 variable "multi_az" {
   type        = bool
-  description = "Set to true if multi AZ deployment must be supported"
   default     = false
+  description = "Set to true if multi AZ deployment must be supported."
 }
 
 variable "storage_type" {
   type        = string
-  description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD)"
   default     = "gp2"
+  description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD)."
 }
 
 variable "storage_encrypted" {
   type        = bool
-  description = "(Optional) Specifies whether the DB instance is encrypted. The default is false if not specified"
   default     = true
+  description = "(Optional) Specifies whether the DB instance is encrypted. The default is false if not specified."
 }
 
 variable "allocated_storage" {
   type        = number
-  description = "The allocated storage in GBs"
   default     = null
+  description = "The allocated storage in GBs."
 }
 
+# http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
+# - mysql
+# - postgres
+# - oracle-*
+# - sqlserver-*
 variable "engine" {
   type        = string
-  description = "Database engine type"
   default     = "postgres"
-  # http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
-  # - mysql
-  # - postgres
-  # - oracle-*
-  # - sqlserver-*
+  description = "Database engine type."
 }
 
+# http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
 variable "engine_version" {
   type        = string
-  description = "Database engine version, depends on engine type"
-  # http://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html
+  description = "Database engine version, depends on engine type."
 }
 
+# https://docs.aws.amazon.com/cli/latest/reference/rds/create-option-group.html
 variable "major_engine_version" {
   type        = string
-  description = "Database MAJOR engine version, depends on engine type"
   default     = ""
-  # https://docs.aws.amazon.com/cli/latest/reference/rds/create-option-group.html
+  description = "Database MAJOR engine version, depends on engine type."
 }
 
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html
 variable "instance_class" {
   type        = string
-  description = "Class of RDS instance"
-  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html
+  description = "Class of RDS instance."
 }
 
 # This is for custom parameters to be passed to the DB
 # We're "cloning" default ones, but we need to specify which should be copied
 variable "db_parameter_group" {
   type        = string
-  description = "The DB parameter group family name. The value depends on DB engine used. See [DBParameterGroupFamily](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBParameterGroup.html#API_CreateDBParameterGroup_RequestParameters) for instructions on how to retrieve applicable value."
-  # "mysql5.6"
-  # "postgres9.5"
+  description = <<-EOT
+    The DB parameter group family name. The value depends on DB engine used.
+    See [DBParameterGroupFamily](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBParameterGroup.html#API_CreateDBParameterGroup_RequestParameters) for instructions on how to retrieve applicable value."
+  EOT
 }
 
 variable "publicly_accessible" {
   type        = bool
-  description = "Determines if database can be publicly available (NOT recommended)"
   default     = false
+  description = "Determines if database can be publicly available (NOT recommended)."
 }
 
 variable "subnet_ids" {
-  description = "List of subnet IDs for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`"
   type        = list(string)
   default     = []
+  description = "List of subnet IDs for the DB. DB instance will be created in the VPC associated with the DB subnet group provisioned using the subnet IDs. Specify one of `subnet_ids`, `db_subnet_group_name` or `availability_zone`."
 }
 
 variable "vpc_id" {
   type        = string
-  description = "VPC ID the DB instance will be created in"
+  description = "VPC ID the DB instance will be created in."
 }
 
 variable "auto_minor_version_upgrade" {
   type        = bool
-  description = "Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4)"
   default     = true
+  description = "Allow automated minor version upgrade (e.g. from Postgres 9.5.3 to Postgres 9.5.4)."
 }
 
 variable "allow_major_version_upgrade" {
   type        = bool
-  description = "Allow major version upgrade"
   default     = false
+  description = "Allow major version upgrade."
 }
 
 variable "apply_immediately" {
   type        = bool
-  description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window"
   default     = false
+  description = "Specifies whether any database modifications are applied immediately, or during the next maintenance window."
 }
 
 variable "maintenance_window" {
   type        = string
-  description = "The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC "
   default     = "Mon:03:00-Mon:04:00"
+  description = "The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi' UTC."
 }
 
 variable "skip_final_snapshot" {
   type        = bool
-  description = "If true (default), no snapshot will be made before deleting DB"
   default     = false
+  description = "If true (default), no snapshot will be made before deleting DB."
 }
 
 variable "copy_tags_to_snapshot" {
   type        = bool
-  description = "Copy tags from DB to a snapshot"
   default     = true
+  description = "Copy tags from DB to a snapshot."
 }
 
 variable "backup_retention_period" {
   type        = number
-  description = "Backup retention period in days. Must be > 0 to enable backups"
   default     = 0
+  description = "Backup retention period in days. Must be > 0 to enable backups."
 }
 
 variable "backup_window" {
   type        = string
-  description = "When AWS can perform DB snapshots, can't overlap with maintenance window"
   default     = "22:00-03:00"
+  description = "When AWS can perform DB snapshots, can't overlap with maintenance window."
 }
 
 variable "db_parameter" {
@@ -185,7 +186,7 @@ variable "db_parameter" {
     value        = string
   }))
   default     = []
-  description = "A list of DB parameters to apply. Note that parameters may differ from a DB family to another"
+  description = "A list of DB parameters to apply. Note that parameters may differ from a DB family to another."
 }
 
 variable "db_options" {
@@ -203,25 +204,25 @@ variable "db_options" {
   }))
 
   default     = []
-  description = "A list of DB options to apply with an option group. Depends on DB engine"
+  description = "A list of DB options to apply with an option group. Depends on DB engine."
 }
 
 variable "parameter_group_name" {
   type        = string
-  description = "Name of the DB parameter group to associate"
   default     = ""
+  description = "Name of the DB parameter group to associate."
 }
 
 variable "option_group_name" {
   type        = string
-  description = "Name of the DB option group to associate"
   default     = ""
+  description = "Name of the DB option group to associate."
 }
 
 variable "kms_key_arn" {
   type        = string
-  description = "The ARN of the existing KMS key to encrypt storage"
   default     = ""
+  description = "The ARN of the existing KMS key to encrypt storage."
 }
 
 variable "enabled_cloudwatch_logs_exports" {
@@ -232,6 +233,66 @@ variable "enabled_cloudwatch_logs_exports" {
 
 variable "ca_cert_identifier" {
   type        = string
-  description = "The identifier of the CA certificate for the DB instance"
   default     = null
+  description = "The identifier of the CA certificate for the DB instance."
+}
+
+variable "proxy_enabled" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to enable RDS proxy. Only available for Postgre and MySQL engines."
+}
+
+variable "proxy_debug_logging" {
+  type        = bool
+  default     = false
+  description = "Whether the proxy includes detailed information about SQL statements in its logs."
+}
+
+variable "proxy_idle_client_timeout" {
+  type        = number
+  default     = 1800
+  description = "The number of seconds that a connection to the proxy can be inactive before the proxy disconnects it."
+}
+
+variable "proxy_require_tls" {
+  type        = bool
+  default     = false
+  description = "A Boolean parameter that specifies whether Transport Layer Security (TLS) encryption is required for connections to the proxy. By enabling this setting, you can enforce encrypted TLS connections to the proxy."
+}
+
+variable "proxy_connection_borrow_timeout" {
+  type        = number
+  default     = 120
+  description = "The number of seconds for a proxy to wait for a connection to become available in the connection pool. Only applies when the proxy has opened its maximum number of connections and all connections are busy with client sessions."
+}
+
+variable "proxy_init_query" {
+  type        = string
+  default     = null
+  description = "One or more SQL statements for the proxy to run when opening each new database connection."
+}
+
+variable "proxy_max_connections_percent" {
+  type        = number
+  default     = 100
+  description = "The maximum size of the connection pool for each target in a target group."
+}
+
+variable "proxy_max_idle_connections_percent" {
+  type        = number
+  default     = 50
+  description = "Controls how actively the proxy closes idle database connections in the connection pool. A high value enables the proxy to leave a high percentage of idle connections open. A low value causes the proxy to close idle client connections and return the underlying database connections to the connection pool."
+}
+
+variable "proxy_session_pinning_filters" {
+  type        = list(string)
+  default     = null
+  description = "Each item in the list represents a class of SQL operations that normally cause all later statements in a session using a proxy to be pinned to the same underlying database connection."
+}
+
+variable "proxy_existing_iam_role_arn" {
+  type        = string
+  default     = null
+  description = "The ARN of an existing IAM role that the proxy can use to access secrets in AWS Secrets Manager. If not provided, the module will create a role to access secrets in Secrets Manager."
 }


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

These changes embeds an RDS proxy in the module.

 - [ ] Bug fix
 - [x] Feature
 - [x] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

BREAKING CHANGE:

The output `instance_id` now returns the database **identifier** instead of the database **id**.

Use the `ressource_id` output to get the database **id**.

## What is the current behavior?

There is no option to add an RDS proxy directly from the module. 

## What is the new behavior?

It is now possible to provision an RDS proxy directly from this module.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [X] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a
